### PR TITLE
argon2-cffi 21.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,14 +16,13 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - flit-core >=3.4,<4
-
   run:
     - python >=3.6
-    - flit-core >=3.4,<4
     - argon2-cffi-bindings
+    - typing-extensions
 
   run_constrained:
     # avoiding argon2-cffi and argon2_cffi to be installed in parallel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,10 @@ build:
 requirements:
   host:
     - python
-    - pip
     - flit-core >=3.4,<4
+    - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
     - argon2-cffi-bindings

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,38 +1,30 @@
 {% set name = "argon2-cffi" %}
-{% set version = "20.1.0" %}
-{% set sha256 = "d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d" %}
+{% set version = "21.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: "d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b"
 
 build:
-  number: 1
-  script:
-    - ln -sf $RANLIB $BUILD_PREFIX/bin/ranlib  # [unix]
-    - {{ PYTHON }} -m pip install . -vv
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build:
-    - {{ compiler("c") }}
-
   host:
-    - python
+    - python >=3.6
     - pip
-    - six
-    - cffi >=1.0.0
-    - enum34  # [py27]
+    - flit-core >=3.4,<4
 
   run:
-    - python
-    - six
-    - cffi >=1.0.0
-    - enum34  # [py27]
+    - python >=3.6
+    - flit-core >=3.4,<4
+    - argon2-cffi-bindings
+
   run_constrained:
     # avoiding argon2-cffi and argon2_cffi to be installed in parallel
     - argon2_cffi ==999
@@ -40,6 +32,10 @@ requirements:
 test:
   imports:
     - argon2
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://argon2-cffi.readthedocs.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: "d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b"
+  sha256: d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b
 
 build:
   number: 0


### PR DESCRIPTION
`notebook`  requires `argon2-cffi` https://github.com/AnacondaRecipes/notebook-feedstock/blob/4efd07ebe5be3f4d05554d33c38291c0f0981d97/recipe/meta.yaml#L29

Changelog: https://github.com/hynek/argon2-cffi/blob/21.3.0/CHANGELOG.md
License: https://github.com/hynek/argon2-cffi/blob/21.3.0/LICENSE
Requirements: https://github.com/hynek/argon2-cffi/blob/21.3.0/pyproject.toml

Actions:
1. Reset build number to `0`
2. Use `noarch: python`
3. Update scripts 
4. Remove `build `and `compiler c`
5. Update host dependencies: add `flit-core >=3.4,<4`, `setuptools`, `wheel`
6. Update run dependencies: `python >=3.6`, add `argon2-cffi-bindings`, `typing-extensions`
7. Add `pip check`