### PR TITLE
argon2_cffi 25.1.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,48 @@
 {% set name = "argon2-cffi" %}
-{% set version = "21.3.0" %}
+{% set version = "25.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d384164d944190a7dd7ef22c6aa3ff197da12962bd04b17f64d4e93d934dba5b
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
+  sha256: 694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<38]
 
 requirements:
   host:
-    - python
-    - flit-core >=3.4,<4
     - pip
-    - setuptools
-    - wheel
+    - python
+    - hatchling
+    - hatch-vcs
+    - hatch-fancy-pypi-readme
   run:
-    - python >=3.6
+    - python
     - argon2-cffi-bindings
-    - typing-extensions
-
   run_constrained:
     # avoiding argon2-cffi and argon2_cffi to be installed in parallel
     - argon2_cffi ==999
 
 test:
+  source_files:
+    - tests
   imports:
     - argon2
-  requires:
-    - pip
   commands:
     - pip check
+    - pytest -v tests
+  requires:
+    - pip
+    - pytest
+    - hypothesis
 
 about:
-  home: https://argon2-cffi.readthedocs.org/
+  home: https://argon2-cffi.readthedocs.org
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -47,8 +50,8 @@ about:
   description: |
     Argon2 won the Password Hashing Competition and argon2_cffi is the simplest
     way to use it in Python and PyPy
-  doc_url: https://argon2-cffi.readthedocs.io/en/stable/
-  dev_url: https://github.com/hynek/argon2_cffi/
+  doc_url: https://argon2-cffi.readthedocs.io
+  dev_url: https://github.com/hynek/argon2_cffi
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
argon2_cffi 25.1.0 

**Destination channel:** Defaults

### Links

- [PKG-11491]
- dev_url:        https://github.com/hynek/argon2_cffi//tree/25.1.0
- conda_forge:    https://github.com/conda-forge/argon2_cffi-feedstock
- pypi:           https://pypi.org/project/argon2_cffi/25.1.0
- pypi inspector: https://inspector.pypi.io/project/argon2_cffi/25.1.0

### Explanation of changes:

- new version number


[PKG-11491]: https://anaconda.atlassian.net/browse/PKG-11491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ