### PR TITLE
PKG-14087: drop argon2_cffi alias from anaconda.yaml packages

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -4,4 +4,3 @@ upstream_sources:
       identifier: argon2-cffi
     packages:
       - argon2-cffi
-      - argon2_cffi


### PR DESCRIPTION
## Summary
Single canonical conda name `argon2-cffi` for PyPI `argon2-cffi` (remove underscore duplicate).

## Ticket
PKG-14087

Made with [Cursor](https://cursor.com)